### PR TITLE
Fix binary linking with npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "url": "https://github.com/jdcrecur/quilk/issues"
   },
   "main": "lib/quilk.js",
-  "bin": "./bin/quilk.js",
+  "bin": {
+    "quilk": "./bin/quilk.js"
+  },
   "files": [
     "bin",
     "lib"


### PR DESCRIPTION
Make sure it links the binary when package is installed.